### PR TITLE
feat: 응답및 에러처리 통일 템플릿 작성

### DIFF
--- a/src/main/java/capstone/capstone01/global/apipayload/ApiResponse.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/ApiResponse.java
@@ -1,0 +1,40 @@
+package capstone.capstone01.global.apipayload;
+
+
+import capstone.capstone01.global.apipayload.code.BaseCode;
+import capstone.capstone01.global.apipayload.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    private final Boolean isSuccess;
+
+    private final String code;
+
+    private final String message;
+
+    private LocalDateTime timestamp;
+
+    private T result;
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(SuccessStatus status, T result){
+        return new ApiResponse<>(true, status.getCode(), status.getMessage(),LocalDateTime.now(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(),LocalDateTime.now(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, LocalDateTime.now(), data);
+    }
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/BaseCode.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/BaseCode.java
@@ -1,0 +1,7 @@
+package capstone.capstone01.global.apipayload.code;
+
+public interface BaseCode {
+    ReasonDTO getReason();
+
+    ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/BaseErrorCode.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package capstone.capstone01.global.apipayload.code;
+
+public interface BaseErrorCode {
+    ErrorReasonDTO getReason();
+
+    ErrorReasonDTO getReasonHttpStatus();
+
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/ErrorReasonDTO.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/ErrorReasonDTO.java
@@ -1,0 +1,20 @@
+package capstone.capstone01.global.apipayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){
+        return isSuccess;
+    }
+
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/ReasonDTO.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/ReasonDTO.java
@@ -1,0 +1,20 @@
+package capstone.capstone01.global.apipayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){
+        return isSuccess;
+    }
+
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
@@ -1,0 +1,54 @@
+package capstone.capstone01.global.apipayload.code.status;
+
+
+import capstone.capstone01.global.apipayload.code.BaseErrorCode;
+import capstone.capstone01.global.apipayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    //일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 회원 관련 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_4001", "해당하는 ID의 사용자가 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_4002", "이미 존재하는 ID 입니다."),
+    MEMBER_ID_NULL(HttpStatus.BAD_REQUEST, "MEMBER_4003", "사용자 아이디는 필수 입니다."),
+    MEMBER_NAME_NULL(HttpStatus.BAD_REQUEST, "MEMBER_4004", "닉네임 입력은 필수 입니다."),
+    MEMBER_INCORRECT_PW(HttpStatus.FORBIDDEN, "MEMBER_4005", "비밀번호가 일치하지 않습니다."),
+
+    //게시물(Post 관련 에러)
+    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4001", "해당하는 게시물이 없습니다."),
+    POST_EDIT_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "POST_4002", "게시물은 작성자만 변경할수 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
@@ -1,0 +1,39 @@
+package capstone.capstone01.global.apipayload.code.status;
+
+import capstone.capstone01.global.apipayload.code.BaseCode;
+import capstone.capstone01.global.apipayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    MEMBER_OK(HttpStatus.OK, "MEMBER_2000", "Member 관련 요청이 성공적으로 수행되었습니다."),
+    POST_OK(HttpStatus.OK, "POST_2000", "Post 관련 요청이 성공적으로 수행되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/capstone/capstone01/global/domain/BaseEntity.java
+++ b/src/main/java/capstone/capstone01/global/domain/BaseEntity.java
@@ -1,0 +1,25 @@
+package capstone.capstone01.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/capstone/capstone01/global/exception/ExceptionAdvice.java
+++ b/src/main/java/capstone/capstone01/global/exception/ExceptionAdvice.java
@@ -1,0 +1,119 @@
+package capstone.capstone01.global.exception;
+
+
+import capstone.capstone01.global.apipayload.ApiResponse;
+import capstone.capstone01.global.apipayload.code.ErrorReasonDTO;
+import capstone.capstone01.global.apipayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/capstone/capstone01/global/exception/GeneralException.java
+++ b/src/main/java/capstone/capstone01/global/exception/GeneralException.java
@@ -1,0 +1,22 @@
+package capstone.capstone01.global.exception;
+
+import capstone.capstone01.global.apipayload.code.BaseErrorCode;
+import capstone.capstone01.global.apipayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+
+}


### PR DESCRIPTION
### 🚩 관련사항
https://github.com/CapstoneDesignCau/Back-End/issues/2

### 📢 전달사항
Entity의 생성 및 수정 날짜를 공통으로 가지게 하기 위해 BaseEntity를 설정하였습니다.
일정한 응답 및 에러 반환을 위해 템플릿 코드를 추가하였습니다.

### 📸 스크린샷
생략

### 📃 코드 변경사항 
- [x] BaseEntity 추가
- [x] 에러 및 응답 통일 템플릿 추가

### 📃 추가로 진행할 작업
- [ ] ExceptionAdvice 코드 추후 필요에 따라 수정

### ⚙️ 기타사항
에러 및 응답 통일 템플릿 사용 방식에 따라 Controller에서 API 응답을 해주어야 합니다.
