### PR TITLE
Feat : 게시글, 댓글 Entity 생성 및 좋아요 기능 구현

### DIFF
--- a/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
+++ b/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
@@ -1,0 +1,45 @@
+package capstone.capstone01.domain.comment.domain;
+
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "commentId")
+    private Long id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @ManyToOne(targetEntity = ImagePost.class)
+    @JoinColumn(name = "imagePostId", nullable = false)
+    private ImagePost imagePost;
+
+    @ManyToOne(targetEntity = User.class)
+    @JoinColumn(name = "userId", nullable = false)
+    private User writer;
+
+    @Column(name = "isDeleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+}

--- a/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
+++ b/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
@@ -6,7 +6,6 @@ import capstone.capstone01.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-
 @Entity
 @Builder
 @Getter

--- a/src/main/java/capstone/capstone01/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/capstone/capstone01/domain/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package capstone.capstone01.domain.comment.domain.repository;
+
+import capstone.capstone01.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/capstone/capstone01/domain/imagepost/controller/ImagePostController.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/controller/ImagePostController.java
@@ -1,6 +1,6 @@
-package capstone.capstone01.domain.post.controller;
+package capstone.capstone01.domain.imagepost.controller;
 
-import capstone.capstone01.domain.post.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
 import capstone.capstone01.global.apipayload.CustomApiResponse;
 import capstone.capstone01.global.apipayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,18 +12,18 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/post")
+@RequestMapping("/api/imagePost")
 @RestController
-public class PostController {
+public class ImagePostController {
 
-    @Operation(summary = "게시물 생성", description = "게시물 생성 API")
+    @Operation(summary = "사진 게시물 생성", description = "사진 게시물 생성 API")
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("")
-    public CustomApiResponse<Long> createPost(
+    public CustomApiResponse<Long> createImagePost(
             @Valid @RequestBody PostCreateRequestDto postCreateRequestDto
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String email = authentication.getName(); // 로그인한 사용자의 이메일(ID)를 가져옴. 이걸 Service 에 매개변수로 전달해서 Service 에서 유저 정보 얻기
+        String email = authentication.getName(); // 로그인한 사용자의 이메일(ID)를 가져옴.
 
         System.out.println(email);
         System.out.println(postCreateRequestDto);

--- a/src/main/java/capstone/capstone01/domain/imagepost/domain/ImagePost.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/domain/ImagePost.java
@@ -1,0 +1,41 @@
+package capstone.capstone01.domain.imagepost.domain;
+
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ImagePost extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "imagePostId")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @ManyToOne(targetEntity = User.class)
+    @JoinColumn(name = "userId", nullable = false)
+    private User writer;
+
+    //TODO: file_save_info 필드에 추가(중간고사 이후 작업 예정)
+
+    @Column(name = "isDeleted")
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    public void update(String title) {
+        this.title = title;
+    }
+
+    public void delete(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+}

--- a/src/main/java/capstone/capstone01/domain/imagepost/domain/repository/ImagePostRepository.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/domain/repository/ImagePostRepository.java
@@ -1,0 +1,8 @@
+package capstone.capstone01.domain.imagepost.domain.repository;
+
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImagePostRepository extends JpaRepository<ImagePost, Long> {
+
+}

--- a/src/main/java/capstone/capstone01/domain/imagepost/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/dto/request/PostCreateRequestDto.java
@@ -1,4 +1,4 @@
-package capstone.capstone01.domain.post.dto.request;
+package capstone.capstone01.domain.imagepost.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
+++ b/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
@@ -21,7 +21,7 @@ public class LikeController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/imagePost/{imagePost-id}")
     public CustomApiResponse<Void> likeImagePost(
-            @PathVariable("imagePost-id") String id
+            @PathVariable("imagePost-id") Long id
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
@@ -29,11 +29,11 @@ public class LikeController {
         return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
     }
 
-    @Operation(summary = "사진 게시글 좋아요 취소 API", description = "사진 게시글 좋아요 취소 API")
+    @Operation(summary = "사진 게시글 좋아요 취소", description = "사진 게시글 좋아요 취소 API")
     @ResponseStatus(value = HttpStatus.OK)
     @PatchMapping("/imagePost/{imagePost-id}")
     public CustomApiResponse<Void> cancelLikePost(
-            @PathVariable("imagePost-id") String id
+            @PathVariable("imagePost-id") Long id
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
@@ -45,7 +45,7 @@ public class LikeController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/comment/{imagePost-id}")
     public CustomApiResponse<Void> likeComment(
-            @PathVariable("imagePost-id") String id
+            @PathVariable("imagePost-id") Long id
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
@@ -53,11 +53,11 @@ public class LikeController {
         return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
     }
 
-    @Operation(summary = "댓글 좋아요 취소 API", description = "댓글 좋아요 취소 API")
+    @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요 취소 API")
     @ResponseStatus(value = HttpStatus.OK)
     @PatchMapping("/comment/{imagePost-id}")
     public CustomApiResponse<Void> cancelLikeComment(
-            @PathVariable("imagePost-id") String id
+            @PathVariable("imagePost-id") Long id
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();

--- a/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
+++ b/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
@@ -1,0 +1,68 @@
+package capstone.capstone01.domain.like.controller;
+
+import capstone.capstone01.domain.like.service.LikeService;
+import capstone.capstone01.global.apipayload.CustomApiResponse;
+import capstone.capstone01.global.apipayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/like")
+@RestController
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @Operation(summary = "사진 게시글 좋아요 저장", description = "사진 게시글 좋아요 저장 API")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping("/imagePost/{imagePost-id}")
+    public CustomApiResponse<Void> likeImagePost(
+            @PathVariable("imagePost-id") String id
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        likeService.likeImagePost(email, id);
+        return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
+    }
+
+    @Operation(summary = "사진 게시글 좋아요 취소 API", description = "사진 게시글 좋아요 취소 API")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PatchMapping("/imagePost/{imagePost-id}")
+    public CustomApiResponse<Void> cancelLikePost(
+            @PathVariable("imagePost-id") String id
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        likeService.cancelLikeImagePost(email, id);
+        return CustomApiResponse.of(SuccessStatus.LIKE_CREATED, null);
+    }
+
+    @Operation(summary = "댓글 좋아요 저장", description = "댓글 좋아요 저장 API")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping("/comment/{imagePost-id}")
+    public CustomApiResponse<Void> likeComment(
+            @PathVariable("imagePost-id") String id
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        likeService.likeComment(email, id);
+        return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
+    }
+
+    @Operation(summary = "댓글 좋아요 취소 API", description = "댓글 좋아요 취소 API")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PatchMapping("/comment/{imagePost-id}")
+    public CustomApiResponse<Void> cancelLikeComment(
+            @PathVariable("imagePost-id") String id
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        likeService.cancelLikeComment(email, id);
+        return CustomApiResponse.of(SuccessStatus.LIKE_CREATED, null);
+    }
+
+}

--- a/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
+++ b/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
@@ -26,7 +26,7 @@ public class LikeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
         likeService.likeImagePost(email, id);
-        return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
+        return CustomApiResponse.of(SuccessStatus.LIKE_CREATED, null);
     }
 
     @Operation(summary = "사진 게시글 좋아요 취소", description = "사진 게시글 좋아요 취소 API")
@@ -38,7 +38,7 @@ public class LikeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
         likeService.cancelLikeImagePost(email, id);
-        return CustomApiResponse.of(SuccessStatus.LIKE_CREATED, null);
+        return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
     }
 
     @Operation(summary = "댓글 좋아요 저장", description = "댓글 좋아요 저장 API")
@@ -50,7 +50,7 @@ public class LikeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
         likeService.likeComment(email, id);
-        return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
+        return CustomApiResponse.of(SuccessStatus.LIKE_CREATED, null);
     }
 
     @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요 취소 API")
@@ -62,7 +62,7 @@ public class LikeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
         likeService.cancelLikeComment(email, id);
-        return CustomApiResponse.of(SuccessStatus.LIKE_CREATED, null);
+        return CustomApiResponse.of(SuccessStatus.LIKE_OK, null);
     }
 
 }

--- a/src/main/java/capstone/capstone01/domain/like/domain/CommentLike.java
+++ b/src/main/java/capstone/capstone01/domain/like/domain/CommentLike.java
@@ -1,0 +1,38 @@
+package capstone.capstone01.domain.like.domain;
+
+import capstone.capstone01.domain.comment.domain.Comment;
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "commentLikeId")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "commentId")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @Column(name = "isDeleted")
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    public void setIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+}

--- a/src/main/java/capstone/capstone01/domain/like/domain/ImagePostLike.java
+++ b/src/main/java/capstone/capstone01/domain/like/domain/ImagePostLike.java
@@ -1,0 +1,37 @@
+package capstone.capstone01.domain.like.domain;
+
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ImagePostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ImagePostLikeId")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "imagePostId")
+    private ImagePost imagePost ;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @Column(name = "isDeleted")
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    public void setIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+}

--- a/src/main/java/capstone/capstone01/domain/like/domain/repository/CommentLikeRepository.java
+++ b/src/main/java/capstone/capstone01/domain/like/domain/repository/CommentLikeRepository.java
@@ -1,0 +1,15 @@
+package capstone.capstone01.domain.like.domain.repository;
+
+import capstone.capstone01.domain.like.domain.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Boolean existsByCommentIdAndUserId(Long commentId, Long userId);
+
+    Optional<CommentLike> findByCommentIdAndUserId(Long commentId, Long userId);
+
+    Long countByCommentIdAndIsDeletedFalse(Long commentId);
+
+}

--- a/src/main/java/capstone/capstone01/domain/like/domain/repository/ImagePostLikeRepository.java
+++ b/src/main/java/capstone/capstone01/domain/like/domain/repository/ImagePostLikeRepository.java
@@ -1,0 +1,15 @@
+package capstone.capstone01.domain.like.domain.repository;
+
+import capstone.capstone01.domain.like.domain.ImagePostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ImagePostLikeRepository extends JpaRepository<ImagePostLike, Long> {
+    Boolean existsByImagePostIdAndUserId(Long imagePostId, Long userId);
+
+    Optional<ImagePostLike> findByImagePostIdAndUserId(Long imagePostId, Long userId);
+
+    Long countByImagePostIdAndIsDeletedFalse(Long imagePostId);
+
+}

--- a/src/main/java/capstone/capstone01/domain/like/service/LikeService.java
+++ b/src/main/java/capstone/capstone01/domain/like/service/LikeService.java
@@ -2,12 +2,12 @@ package capstone.capstone01.domain.like.service;
 
 public interface LikeService {
 
-    void likeImagePost(String email, String imagePostId);
+    void likeImagePost(String email, Long imagePostId);
 
-    void cancelLikeImagePost(String email, String imagePostId);
+    void cancelLikeImagePost(String email, Long imagePostId);
 
-    void likeComment(String email, String commentId);
+    void likeComment(String email, Long commentId);
 
-    void cancelLikeComment(String email, String commentId);
+    void cancelLikeComment(String email, Long commentId);
 
 }

--- a/src/main/java/capstone/capstone01/domain/like/service/LikeService.java
+++ b/src/main/java/capstone/capstone01/domain/like/service/LikeService.java
@@ -1,0 +1,13 @@
+package capstone.capstone01.domain.like.service;
+
+public interface LikeService {
+
+    void likeImagePost(String email, String imagePostId);
+
+    void cancelLikeImagePost(String email, String imagePostId);
+
+    void likeComment(String email, String commentId);
+
+    void cancelLikeComment(String email, String commentId);
+
+}

--- a/src/main/java/capstone/capstone01/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/like/service/LikeServiceImpl.java
@@ -1,27 +1,136 @@
 package capstone.capstone01.domain.like.service;
 
+import capstone.capstone01.domain.comment.domain.Comment;
+import capstone.capstone01.domain.comment.domain.repository.CommentRepository;
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.imagepost.domain.repository.ImagePostRepository;
+import capstone.capstone01.domain.like.domain.CommentLike;
+import capstone.capstone01.domain.like.domain.ImagePostLike;
+import capstone.capstone01.domain.like.domain.repository.CommentLikeRepository;
+import capstone.capstone01.domain.like.domain.repository.ImagePostLikeRepository;
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.domain.user.domain.repository.UserRepository;
+import capstone.capstone01.global.apipayload.code.status.ErrorStatus;
+import capstone.capstone01.global.exception.specific.CommentException;
+import capstone.capstone01.global.exception.specific.ImagePostException;
+import capstone.capstone01.global.exception.specific.LikeException;
+import capstone.capstone01.global.exception.specific.UserException;
+import capstone.capstone01.global.util.converter.LikeConverter;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class LikeServiceImpl implements LikeService {
 
+    private final ImagePostLikeRepository imagePostLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final ImagePostRepository imagePostRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
     @Override
-    public void likeImagePost(String email, String imagePostId) {
-        // 이미지 게시글에 좋아요를 누르는 로직 구현
+    public void likeImagePost(String email, Long imagePostId) {
+        User user = getUserByEmail(email);
+        ImagePost imagePost = getImagePostById(imagePostId);
+
+        ImagePostLike imagePostLike;
+        if (isImagePostAlreadyLiked(user, imagePostId)) {
+            imagePostLike = getImagePostLike(user, imagePostId);
+            if (imagePostLike.getIsDeleted()) {
+                imagePostLike.setIsDeleted(false);
+            } else {
+                throw new LikeException(ErrorStatus.POST_ALREADY_LIKE);
+            }
+        } else {
+            imagePostLike = LikeConverter.toImagePostLike(user, imagePost);
+        }
+
+        imagePostLikeRepository.save(imagePostLike);
     }
 
     @Override
-    public void cancelLikeImagePost(String email, String imagePostId) {
-        // 이미지 게시글에 좋아요를 취소하는 로직 구현
+    public void cancelLikeImagePost(String email, Long imagePostId) {
+        User user = getUserByEmail(email);
+
+        ImagePostLike imagePostLike = getImagePostLike(user, imagePostId);
+
+        if (imagePostLike.getIsDeleted()) {
+            throw new LikeException(ErrorStatus.POST_LIKE_ALREADY_DELETED);
+        }
+
+        imagePostLike.setIsDeleted(true);
+        imagePostLikeRepository.save(imagePostLike);
     }
 
     @Override
-    public void likeComment(String email, String commentId) {
-        // 댓글에 좋아요를 누르는 로직 구현
+    public void likeComment(String email, Long commentId) {
+        User user = getUserByEmail(email);
+        Comment comment = getCommentById(commentId);
+
+        CommentLike commentLike;
+        if (isCommentAlreadyLiked(user, commentId)) {
+            commentLike = getCommentLike(user, commentId);
+            if (commentLike.getIsDeleted()) {
+                commentLike.setIsDeleted(false);
+            } else {
+                throw new LikeException(ErrorStatus.COMMENT_ALREADY_LIKE);
+            }
+        } else {
+            commentLike = LikeConverter.toCommentLike(user, comment);
+        }
+
+        commentLikeRepository.save(commentLike);
     }
 
     @Override
-    public void cancelLikeComment(String email, String commentId) {
-        // 댓글에 좋아요를 취소하는 로직 구현
+    public void cancelLikeComment(String email, Long commentId) {
+        User user = getUserByEmail(email);
+
+        CommentLike commentLike = getCommentLike(user, commentId);
+
+        if (commentLike.getIsDeleted()) {
+            throw new LikeException(ErrorStatus.COMMENT_LIKE_ALREADY_DELETED);
+        }
+
+        commentLike.setIsDeleted(true);
+        commentLikeRepository.save(commentLike);
+    }
+
+    private User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private ImagePost getImagePostById(Long imagePostId) {
+        return imagePostRepository.findById(imagePostId)
+                .orElseThrow(() -> new ImagePostException(ErrorStatus.POST_NOT_FOUND));
+    }
+
+    private Comment getCommentById(Long commentId) {
+        return commentRepository.findById(commentId).
+                orElseThrow(() -> new CommentException(ErrorStatus.COMMENT_NOT_FOUND));
+    }
+
+    private Boolean isImagePostAlreadyLiked(User user, Long imagePostId) {
+        return imagePostLikeRepository.existsByImagePostIdAndUserId(imagePostId, user.getId());
+    }
+
+    private Boolean isCommentAlreadyLiked(User user, Long commentId) {
+        return commentLikeRepository.existsByCommentIdAndUserId(commentId, user.getId());
+    }
+
+    private ImagePostLike getImagePostLike(User user, Long imagePostId) {
+        return imagePostLikeRepository.findByImagePostIdAndUserId(imagePostId, user.getId())
+                .orElseThrow(() -> new LikeException(ErrorStatus.POST_LIKE_NOT_FOUND));
+    }
+
+    private CommentLike getCommentLike(User user, Long commentId) {
+        return commentLikeRepository.findByCommentIdAndUserId(commentId, user.getId()).orElseThrow(
+                () -> new LikeException(ErrorStatus.COMMENT_LIKE_NOT_FOUND));
     }
 }

--- a/src/main/java/capstone/capstone01/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/like/service/LikeServiceImpl.java
@@ -16,9 +16,7 @@ import capstone.capstone01.global.exception.specific.ImagePostException;
 import capstone.capstone01.global.exception.specific.LikeException;
 import capstone.capstone01.global.exception.specific.UserException;
 import capstone.capstone01.global.util.converter.LikeConverter;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,18 +100,15 @@ public class LikeServiceImpl implements LikeService {
     }
 
     private User getUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+        return userRepository.findByEmail(email).orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
     }
 
     private ImagePost getImagePostById(Long imagePostId) {
-        return imagePostRepository.findById(imagePostId)
-                .orElseThrow(() -> new ImagePostException(ErrorStatus.POST_NOT_FOUND));
+        return imagePostRepository.findById(imagePostId).orElseThrow(() -> new ImagePostException(ErrorStatus.POST_NOT_FOUND));
     }
 
     private Comment getCommentById(Long commentId) {
-        return commentRepository.findById(commentId).
-                orElseThrow(() -> new CommentException(ErrorStatus.COMMENT_NOT_FOUND));
+        return commentRepository.findById(commentId).orElseThrow(() -> new CommentException(ErrorStatus.COMMENT_NOT_FOUND));
     }
 
     private Boolean isImagePostAlreadyLiked(User user, Long imagePostId) {
@@ -125,12 +120,10 @@ public class LikeServiceImpl implements LikeService {
     }
 
     private ImagePostLike getImagePostLike(User user, Long imagePostId) {
-        return imagePostLikeRepository.findByImagePostIdAndUserId(imagePostId, user.getId())
-                .orElseThrow(() -> new LikeException(ErrorStatus.POST_LIKE_NOT_FOUND));
+        return imagePostLikeRepository.findByImagePostIdAndUserId(imagePostId, user.getId()).orElseThrow(() -> new LikeException(ErrorStatus.POST_LIKE_NOT_FOUND));
     }
 
     private CommentLike getCommentLike(User user, Long commentId) {
-        return commentLikeRepository.findByCommentIdAndUserId(commentId, user.getId()).orElseThrow(
-                () -> new LikeException(ErrorStatus.COMMENT_LIKE_NOT_FOUND));
+        return commentLikeRepository.findByCommentIdAndUserId(commentId, user.getId()).orElseThrow(() -> new LikeException(ErrorStatus.COMMENT_LIKE_NOT_FOUND));
     }
 }

--- a/src/main/java/capstone/capstone01/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/like/service/LikeServiceImpl.java
@@ -1,0 +1,27 @@
+package capstone.capstone01.domain.like.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LikeServiceImpl implements LikeService {
+
+    @Override
+    public void likeImagePost(String email, String imagePostId) {
+        // 이미지 게시글에 좋아요를 누르는 로직 구현
+    }
+
+    @Override
+    public void cancelLikeImagePost(String email, String imagePostId) {
+        // 이미지 게시글에 좋아요를 취소하는 로직 구현
+    }
+
+    @Override
+    public void likeComment(String email, String commentId) {
+        // 댓글에 좋아요를 누르는 로직 구현
+    }
+
+    @Override
+    public void cancelLikeComment(String email, String commentId) {
+        // 댓글에 좋아요를 취소하는 로직 구현
+    }
+}

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
@@ -29,6 +29,17 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4001", "해당하는 게시물이 없습니다."),
     POST_EDIT_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "POST_4002", "게시물은 작성자만 변경할수 있습니다."),
 
+    //댓글 관련 에러
+    COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT_4001", "해당하는 댓글이 없습니다."),
+
+    //좋아요 관련 에러
+    POST_ALREADY_LIKE(HttpStatus.BAD_REQUEST, "LIKE_4001", "해당하는 게시글은 이미 좋아요인 상태입니다."),
+    POST_LIKE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "LIKE_4002", "해당하는 게시글은 이미 좋아요가 취소 된 상태입니다."),
+    POST_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "LIKE_4003", "해당하는 게시글의 좋아요 내역을 찾을 수 없습니다."),
+    COMMENT_ALREADY_LIKE(HttpStatus.BAD_REQUEST, "LIKE_4004", "해당하는 댓글은 이미 좋아요인 상태입니다."),
+    COMMENT_LIKE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "LIKE_4005", "해당하는 댓글은 이미 좋아요가 취소 된 상태입니다."),
+    COMMENT_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "LIKE_4006", "해당하는 댓글의 좋아요 내역을 찾을 수 없습니다."),
+
     //파일 관련 에러
     FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "FILE_4001", "S3에 파일을 저장하는 것을 실패했습니다."),
     FILE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "FILE_4002", "S3에 파일을 삭제하는 것을 실패했습니다."),

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
@@ -15,8 +15,12 @@ public enum SuccessStatus implements BaseCode {
 
     POST_OK(HttpStatus.OK, "POST_2000", "Post 관련 요청이 성공적으로 수행되었습니다."),
 
+    LIKE_OK(HttpStatus.OK, "LIKE_2000", "Like 관련 요청이 성공적으로 수행되었습니다."),
+    LIKE_CREATED(HttpStatus.CREATED, "LIKE_2001", "LIKE 관련 요청이 성공적으로 생성되었습니다."),
+
     FILE_UPLOAD_OK(HttpStatus.OK, "FILE_2000", "FILE 관련 요청이 성공적으로 수행되었습니다."),
     FILE_DELETE_OK(HttpStatus.OK, "FILE_2001", "FILE 삭제 요청이 성공적으로 수행되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/capstone/capstone01/global/exception/specific/CommentException.java
+++ b/src/main/java/capstone/capstone01/global/exception/specific/CommentException.java
@@ -1,0 +1,10 @@
+package capstone.capstone01.global.exception.specific;
+
+import capstone.capstone01.global.apipayload.code.BaseErrorCode;
+import capstone.capstone01.global.exception.GeneralException;
+
+public class CommentException extends GeneralException {
+    public CommentException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/capstone/capstone01/global/exception/specific/ImagePostException.java
+++ b/src/main/java/capstone/capstone01/global/exception/specific/ImagePostException.java
@@ -1,0 +1,10 @@
+package capstone.capstone01.global.exception.specific;
+
+import capstone.capstone01.global.apipayload.code.BaseErrorCode;
+import capstone.capstone01.global.exception.GeneralException;
+
+public class ImagePostException extends GeneralException {
+    public ImagePostException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/capstone/capstone01/global/exception/specific/LikeException.java
+++ b/src/main/java/capstone/capstone01/global/exception/specific/LikeException.java
@@ -1,0 +1,10 @@
+package capstone.capstone01.global.exception.specific;
+
+import capstone.capstone01.global.apipayload.code.BaseErrorCode;
+import capstone.capstone01.global.exception.GeneralException;
+
+public class LikeException extends GeneralException {
+    public LikeException(BaseErrorCode baseErrorCode){
+            super(baseErrorCode);
+    }
+}

--- a/src/main/java/capstone/capstone01/global/util/converter/LikeConverter.java
+++ b/src/main/java/capstone/capstone01/global/util/converter/LikeConverter.java
@@ -1,0 +1,26 @@
+package capstone.capstone01.global.util.converter;
+
+import capstone.capstone01.domain.comment.domain.Comment;
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.like.domain.CommentLike;
+import capstone.capstone01.domain.like.domain.ImagePostLike;
+import capstone.capstone01.domain.user.domain.User;
+
+public class LikeConverter {
+
+    public static ImagePostLike toImagePostLike(User user, ImagePost imagePost) {
+        return ImagePostLike.builder()
+                .user(user)
+                .imagePost(imagePost)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static CommentLike toCommentLike(User user, Comment comment) {
+        return CommentLike.builder()
+                .user(user)
+                .comment(comment)
+                .isDeleted(false)
+                .build();
+    }
+}


### PR DESCRIPTION
### 🚩 관련사항
https://github.com/CapstoneDesignCau/Back-End/issues/15

### 📢 전달사항
ERD 다이어그램을 기반으로 ImagePost, Comment Entity를 새롭게 추가하였고, ImagePost와 Comment에 좋아요를 누르고, 좋아요를 취소하는 기능을 완성하였습니다.

### 📸 스크린샷
-게시글 좋아요
1. 처음 좋아요를 누른 경우
![좋아요 생성](https://github.com/user-attachments/assets/1902e70f-a733-4d3e-ba34-0cd8856b905e)

2. 좋아요가 누른 상태에서 좋아요 요청을 한번 더 누른 경우
![좋아요 취소](https://github.com/user-attachments/assets/257219ea-b7df-486d-8ef1-45eedd537948)


3. 좋아요를 취소한 게시글에 다시 좋아요를 보내는 경우
![3](https://github.com/user-attachments/assets/a44e4bdd-b2f1-4259-ad9c-561e5cc14c89)

-게시글 좋아요 취소
1. 좋아요가 없는 상태에서 바로 취소 누른 경우
![게시글 좋아요가 없는데 취소누른 경우](https://github.com/user-attachments/assets/d48c435a-80c1-4474-9518-77a01b8a4c33)

2. 좋아요가 된 상태에서 취소 누른 경우
![좋아요 취소1](https://github.com/user-attachments/assets/d8c2f603-5641-499e-ab19-5680d93a3f0c)

3. 취소된 상황에서 한번 더 취소 요청 API를 보내는 경우
![좋아요 취소2](https://github.com/user-attachments/assets/c7357e7d-8469-4832-8e33-dbe4aff310d9)

댓글 좋아요, 취소도 위와 동일함을 확인했습니다.

### 📃 코드 변경사항 
- [x] ImagePost Entity 생성
- [x] Comment Entity 생성
- [x] Post, Comment 좋아요 생성 기능 추가
- [x] Post, Comment 좋아요 취소 기능 추가

### 📃 추가로 진행할 작업
- [ ] ImagePost Controller 제작
- [ ] Comment Controller 제작

### ⚙️ 기타사항
ImagePost에 사진 파일을 연결하는 작업은 중간고사 이후에 진행 예정