### PR TITLE
Feat : 게시글 댓글 생성, 삭제, 조회 로직 추가

### DIFF
--- a/src/main/java/capstone/capstone01/domain/comment/controller/CommentController.java
+++ b/src/main/java/capstone/capstone01/domain/comment/controller/CommentController.java
@@ -1,0 +1,55 @@
+package capstone.capstone01.domain.comment.controller;
+
+import capstone.capstone01.domain.comment.dto.request.CommentCreateRequestDto;
+import capstone.capstone01.domain.comment.dto.response.CommentResponseDto;
+import capstone.capstone01.domain.comment.service.CommentService;
+import capstone.capstone01.global.apipayload.CustomApiResponse;
+import capstone.capstone01.global.apipayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/comment")
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 생성", description = "댓글 생성 API")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping("")
+    public CustomApiResponse<Long> createComment(
+            @Valid @RequestBody CommentCreateRequestDto commentCreateRequestDto
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName(); // 로그인한 사용자의 이메일(ID)를 가져옴.
+
+        Long commentId = commentService.createComment(email, commentCreateRequestDto);
+        return CustomApiResponse.of(SuccessStatus.COMMENT_CREATED, commentId);
+    }
+
+    @Operation(summary = "댓글 조회", description = "댓글 조회 API")
+    @ResponseStatus(value = HttpStatus.OK)
+    @GetMapping("/{comment-Id}")
+    public CustomApiResponse<CommentResponseDto> getComment(@PathVariable("comment-Id") Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        CommentResponseDto commentResponseDto = commentService.getComment(email, id);
+        return CustomApiResponse.of(SuccessStatus.COMMENT_OK, commentResponseDto);
+    }
+
+    @Operation(summary = "댓글 삭제", description = "댓글 삭제 API")
+    @ResponseStatus(value = HttpStatus.OK)
+    @DeleteMapping("/{comment-Id}")
+    public CustomApiResponse<Void> deleteComment(@PathVariable("comment-Id") Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        commentService.deleteComment(email, id);
+        return CustomApiResponse.of(SuccessStatus.COMMENT_OK, null);
+    }
+}

--- a/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
+++ b/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
@@ -37,8 +37,8 @@ public class Comment extends BaseEntity {
         this.content = content;
     }
 
-    public void delete() {
-        this.isDeleted = true;
+    public void delete(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 
     public void setImagePost(ImagePost imagePost) {

--- a/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
+++ b/src/main/java/capstone/capstone01/domain/comment/domain/Comment.java
@@ -41,4 +41,8 @@ public class Comment extends BaseEntity {
         this.isDeleted = true;
     }
 
+    public void setImagePost(ImagePost imagePost) {
+        this.imagePost = imagePost;
+    }
+
 }

--- a/src/main/java/capstone/capstone01/domain/comment/dto/request/CommentCreateRequestDto.java
+++ b/src/main/java/capstone/capstone01/domain/comment/dto/request/CommentCreateRequestDto.java
@@ -1,0 +1,21 @@
+package capstone.capstone01.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateRequestDto {
+
+    @Schema(description = "이미지 게시물 ID", example = "1")
+    private Long imagePostId;
+
+    @Schema(description = "댓글 내용", example = "This is a comment.")
+    private String content;
+
+}

--- a/src/main/java/capstone/capstone01/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/capstone/capstone01/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,23 @@
+package capstone.capstone01.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentResponseDto {
+
+    @Schema(description = "댓글 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "댓글 내용", example = "테스트 댓글 내용")
+    private String content;
+
+    @Schema(description = "작성자 닉네임", example = "푸앙이")
+    private String writerNickname;
+
+    @Schema(description = "댓글 삭제 여부", example = "false")
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/capstone/capstone01/domain/comment/service/CommentService.java
+++ b/src/main/java/capstone/capstone01/domain/comment/service/CommentService.java
@@ -1,0 +1,14 @@
+package capstone.capstone01.domain.comment.service;
+
+import capstone.capstone01.domain.comment.dto.request.CommentCreateRequestDto;
+import capstone.capstone01.domain.comment.dto.response.CommentResponseDto;
+
+public interface CommentService {
+
+    Long createComment(String email, CommentCreateRequestDto commentCreateRequestDto);
+
+    CommentResponseDto getComment(String email, Long id);
+
+    void deleteComment(String email, Long id);
+
+}

--- a/src/main/java/capstone/capstone01/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,77 @@
+package capstone.capstone01.domain.comment.service;
+
+import capstone.capstone01.domain.comment.domain.Comment;
+import capstone.capstone01.domain.comment.domain.repository.CommentRepository;
+import capstone.capstone01.domain.comment.dto.request.CommentCreateRequestDto;
+import capstone.capstone01.domain.comment.dto.response.CommentResponseDto;
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.imagepost.domain.repository.ImagePostRepository;
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.domain.user.domain.enums.UserRole;
+import capstone.capstone01.domain.user.domain.repository.UserRepository;
+import capstone.capstone01.global.apipayload.code.status.ErrorStatus;
+import capstone.capstone01.global.exception.specific.CommentException;
+import capstone.capstone01.global.exception.specific.ImagePostException;
+import capstone.capstone01.global.exception.specific.UserException;
+import capstone.capstone01.global.util.converter.CommentConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final ImagePostRepository imagePostRepository;
+
+    @Override
+    public Long createComment(String email, CommentCreateRequestDto commentCreateRequestDto) {
+        User user = findUserByEmail(email);
+        ImagePost imagePost = findImagePostById(commentCreateRequestDto.getImagePostId());
+
+        Comment comment = CommentConverter.toComment(commentCreateRequestDto, user, imagePost);
+        commentRepository.save(comment);
+        return comment.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CommentResponseDto getComment(String email, Long id) {
+        Comment comment = findCommentById(id);
+
+        return CommentConverter.toCommentResponseDto(comment);
+    }
+
+    @Override
+    public void deleteComment(String email, Long id) {
+        User user = findUserByEmail(email);
+        Comment comment = findCommentById(id);
+
+        if (user.getRole() == UserRole.ADMIN || comment.getWriter().getEmail().equals(email)) {
+            ImagePost imagePost = comment.getImagePost();
+            imagePost.removeComment(comment); // Ensure bidirectional mapping
+            comment.delete(true);
+            commentRepository.save(comment);
+        } else {
+            throw new CommentException(ErrorStatus.COMMENT_DELETE_NOT_ALLOWED);
+        }
+    }
+
+    private User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private ImagePost findImagePostById(Long id) {
+        return imagePostRepository.findById(id)
+                .orElseThrow(() -> new ImagePostException(ErrorStatus.POST_NOT_FOUND));
+    }
+
+    private Comment findCommentById(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(() -> new CommentException(ErrorStatus.COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/capstone/capstone01/domain/imagepost/controller/ImagePostController.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/controller/ImagePostController.java
@@ -1,6 +1,8 @@
 package capstone.capstone01.domain.imagepost.controller;
 
 import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
+import capstone.capstone01.domain.imagepost.service.ImagePostService;
 import capstone.capstone01.global.apipayload.CustomApiResponse;
 import capstone.capstone01.global.apipayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class ImagePostController {
 
+    private final ImagePostService imagePostService;
+
     @Operation(summary = "사진 게시물 생성", description = "사진 게시물 생성 API")
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("")
@@ -25,10 +29,30 @@ public class ImagePostController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName(); // 로그인한 사용자의 이메일(ID)를 가져옴.
 
-        System.out.println(email);
-        System.out.println(postCreateRequestDto);
-        return CustomApiResponse.of(SuccessStatus.POST_OK, 1L);
+        Long postId = imagePostService.createImagePost(email, postCreateRequestDto);
+        return CustomApiResponse.of(SuccessStatus.POST_CREATED, postId);
     }
 
+    @Operation(summary = "사진 게시물 조회", description = "사진 게시물 조회 API")
+    @ResponseStatus(value = HttpStatus.OK)
+    @GetMapping("/{imagePost-id}")
+    public CustomApiResponse<ImagePostResponseDto> getImagePost(@PathVariable("imagePost-id") Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        ImagePostResponseDto imagePostResponseDto = imagePostService.getImagePost(email, id);
+        return CustomApiResponse.of(SuccessStatus.POST_OK, imagePostResponseDto);
+    }
+
+    @Operation(summary = "사진 게시물 삭제", description = "사진 게시물 삭제 API")
+    @ResponseStatus(value = HttpStatus.OK)
+    @DeleteMapping("/{imagePost-id}")
+    public CustomApiResponse<Void> deleteImagePost(@PathVariable("imagePost-id") Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        imagePostService.deleteImagePost(email, id);
+        return CustomApiResponse.of(SuccessStatus.POST_OK, null);
+    }
 
 }

--- a/src/main/java/capstone/capstone01/domain/imagepost/controller/ImagePostController.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/controller/ImagePostController.java
@@ -1,6 +1,6 @@
 package capstone.capstone01.domain.imagepost.controller;
 
-import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.request.ImagePostCreateRequestDto;
 import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
 import capstone.capstone01.domain.imagepost.service.ImagePostService;
 import capstone.capstone01.global.apipayload.CustomApiResponse;
@@ -24,12 +24,12 @@ public class ImagePostController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("")
     public CustomApiResponse<Long> createImagePost(
-            @Valid @RequestBody PostCreateRequestDto postCreateRequestDto
+            @Valid @RequestBody ImagePostCreateRequestDto imagePostCreateRequestDto
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName(); // 로그인한 사용자의 이메일(ID)를 가져옴.
 
-        Long postId = imagePostService.createImagePost(email, postCreateRequestDto);
+        Long postId = imagePostService.createImagePost(email, imagePostCreateRequestDto);
         return CustomApiResponse.of(SuccessStatus.POST_CREATED, postId);
     }
 

--- a/src/main/java/capstone/capstone01/domain/imagepost/domain/ImagePost.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/domain/ImagePost.java
@@ -30,6 +30,10 @@ public class ImagePost extends BaseEntity {
 
     //TODO: file_save_info 필드에 추가(중간고사 이후 작업 예정)
 
+    @Column(name="isOpen", nullable = false)
+    @Builder.Default
+    private Boolean isOpen = true;
+
     @OneToMany(mappedBy = "imagePost", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/capstone/capstone01/domain/imagepost/domain/ImagePost.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/domain/ImagePost.java
@@ -1,9 +1,13 @@
 package capstone.capstone01.domain.imagepost.domain;
 
+import capstone.capstone01.domain.comment.domain.Comment;
 import capstone.capstone01.domain.user.domain.User;
 import capstone.capstone01.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -26,6 +30,9 @@ public class ImagePost extends BaseEntity {
 
     //TODO: file_save_info 필드에 추가(중간고사 이후 작업 예정)
 
+    @OneToMany(mappedBy = "imagePost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
     @Column(name = "isDeleted")
     @Builder.Default
     private Boolean isDeleted = false;
@@ -38,4 +45,12 @@ public class ImagePost extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setImagePost(this);
+    }
+
+    public void removeComment(Comment comment) {
+        comments.remove(comment);
+    }
 }

--- a/src/main/java/capstone/capstone01/domain/imagepost/dto/request/ImagePostCreateRequestDto.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/dto/request/ImagePostCreateRequestDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PostCreateRequestDto {
+public class ImagePostCreateRequestDto {
 
     @NotBlank(message = "게시글 제목을 입력해주세요.")
     @Schema(description = "게시글 제목", example = "test 게시글입니다.")

--- a/src/main/java/capstone/capstone01/domain/imagepost/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/dto/request/PostCreateRequestDto.java
@@ -2,6 +2,7 @@ package capstone.capstone01.domain.imagepost.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +18,8 @@ public class PostCreateRequestDto {
     @Schema(description = "게시글 제목", example = "test 게시글입니다.")
     private String title;
 
-    @NotBlank(message = "게시글 내용을 입력해주세요.")
-    @Schema(description = "게시글 내용", example = "게시글 내용")
-    private String text;
+    @NotNull(message = "게시글 공개 여부를 입력해주세요.")
+    @Schema(description = "게시글 공개 여부", example = "true")
+    private Boolean isOpen;
 
 }

--- a/src/main/java/capstone/capstone01/domain/imagepost/dto/response/ImagePostResponseDto.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/dto/response/ImagePostResponseDto.java
@@ -1,0 +1,26 @@
+package capstone.capstone01.domain.imagepost.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ImagePostResponseDto {
+
+    @Schema(description = "게시물 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "게시물 제목", example = "test 게시글입니다.")
+    private String title;
+
+    @Schema(description = "작성자 닉네임", example = "개발자푸앙이")
+    private String writerNickname;
+
+    @Schema(description = "게시물 공개 여부", example = "true")
+    private Boolean isOpen;
+
+    @Schema(description = "게시물 삭제 여부", example = "false")
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostService.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostService.java
@@ -1,0 +1,14 @@
+package capstone.capstone01.domain.imagepost.service;
+
+import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
+
+public interface ImagePostService {
+
+    Long createImagePost(String email, PostCreateRequestDto postCreateRequestDto);
+
+    ImagePostResponseDto getImagePost(String email, Long id);
+
+    void deleteImagePost(String email, Long id);
+
+}

--- a/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostService.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostService.java
@@ -1,11 +1,11 @@
 package capstone.capstone01.domain.imagepost.service;
 
-import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.request.ImagePostCreateRequestDto;
 import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
 
 public interface ImagePostService {
 
-    Long createImagePost(String email, PostCreateRequestDto postCreateRequestDto);
+    Long createImagePost(String email, ImagePostCreateRequestDto imagePostCreateRequestDto);
 
     ImagePostResponseDto getImagePost(String email, Long id);
 

--- a/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostServiceImpl.java
@@ -2,7 +2,7 @@ package capstone.capstone01.domain.imagepost.service;
 
 import capstone.capstone01.domain.imagepost.domain.ImagePost;
 import capstone.capstone01.domain.imagepost.domain.repository.ImagePostRepository;
-import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.request.ImagePostCreateRequestDto;
 import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
 import capstone.capstone01.domain.user.domain.User;
 import capstone.capstone01.domain.user.domain.enums.UserRole;
@@ -24,9 +24,9 @@ public class ImagePostServiceImpl implements ImagePostService {
     private final UserRepository userRepository;
 
     @Override
-    public Long createImagePost(String email, PostCreateRequestDto postCreateRequestDto) {
+    public Long createImagePost(String email, ImagePostCreateRequestDto imagePostCreateRequestDto) {
         User user = findUserByEmail(email);
-        ImagePost imagePost = ImagePostConverter.toImagePost(postCreateRequestDto, user);
+        ImagePost imagePost = ImagePostConverter.toImagePost(imagePostCreateRequestDto, user);
 
         imagePostRepository.save(imagePost);
         return imagePost.getId();

--- a/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostServiceImpl.java
@@ -33,6 +33,7 @@ public class ImagePostServiceImpl implements ImagePostService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ImagePostResponseDto getImagePost(String email, Long id) {
         User user = findUserByEmail(email);
         ImagePost imagePost = findImagePostById(id);

--- a/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostServiceImpl.java
+++ b/src/main/java/capstone/capstone01/domain/imagepost/service/ImagePostServiceImpl.java
@@ -1,0 +1,69 @@
+package capstone.capstone01.domain.imagepost.service;
+
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.imagepost.domain.repository.ImagePostRepository;
+import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
+import capstone.capstone01.domain.user.domain.User;
+import capstone.capstone01.domain.user.domain.enums.UserRole;
+import capstone.capstone01.domain.user.domain.repository.UserRepository;
+import capstone.capstone01.global.apipayload.code.status.ErrorStatus;
+import capstone.capstone01.global.exception.specific.ImagePostException;
+import capstone.capstone01.global.exception.specific.UserException;
+import capstone.capstone01.global.util.converter.ImagePostConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImagePostServiceImpl implements ImagePostService {
+
+    private final ImagePostRepository imagePostRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public Long createImagePost(String email, PostCreateRequestDto postCreateRequestDto) {
+        User user = findUserByEmail(email);
+        ImagePost imagePost = ImagePostConverter.toImagePost(postCreateRequestDto, user);
+
+        imagePostRepository.save(imagePost);
+        return imagePost.getId();
+    }
+
+    @Override
+    public ImagePostResponseDto getImagePost(String email, Long id) {
+        User user = findUserByEmail(email);
+        ImagePost imagePost = findImagePostById(id);
+
+        if (user.getRole() == UserRole.ADMIN || imagePost.getIsOpen() || imagePost.getWriter().getEmail().equals(email)) {
+            return ImagePostConverter.toImagePostResponseDto(imagePost);
+        } else {
+            throw new ImagePostException(ErrorStatus.POST_READ_NOT_ALLOWED);
+        }
+    }
+
+    @Override
+    public void deleteImagePost(String email, Long id) {
+        User user = findUserByEmail(email);
+        ImagePost imagePost = findImagePostById(id);
+
+        if (user.getRole() == UserRole.ADMIN || imagePost.getWriter().getEmail().equals(email)) {
+            imagePost.delete(true);
+            imagePostRepository.save(imagePost);
+        } else {
+            throw new ImagePostException(ErrorStatus.POST_DELETE_NOT_ALLOWED);
+        }
+    }
+
+    private User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private ImagePost findImagePostById(Long id) {
+        return imagePostRepository.findById(id)
+                .orElseThrow(() -> new ImagePostException(ErrorStatus.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
+++ b/src/main/java/capstone/capstone01/domain/like/controller/LikeController.java
@@ -43,9 +43,9 @@ public class LikeController {
 
     @Operation(summary = "댓글 좋아요 저장", description = "댓글 좋아요 저장 API")
     @ResponseStatus(value = HttpStatus.CREATED)
-    @PostMapping("/comment/{imagePost-id}")
+    @PostMapping("/comment/{comment-id}")
     public CustomApiResponse<Void> likeComment(
-            @PathVariable("imagePost-id") Long id
+            @PathVariable("comment-id") Long id
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
@@ -55,9 +55,9 @@ public class LikeController {
 
     @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요 취소 API")
     @ResponseStatus(value = HttpStatus.OK)
-    @PatchMapping("/comment/{imagePost-id}")
+    @PatchMapping("/comment/{comment-id}")
     public CustomApiResponse<Void> cancelLikeComment(
-            @PathVariable("imagePost-id") Long id
+            @PathVariable("comment-id") Long id
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
@@ -25,9 +25,11 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_INCORRECT_PW(HttpStatus.FORBIDDEN, "USER_4005", "비밀번호가 일치하지 않습니다."),
     USER_NICKNAME_EXISTS(HttpStatus.CONFLICT, "USER_4006", "이미 존재하는 닉네임 입니다."),
 
-    //게시물(Post 관련 에러)
+    //게시물 관련 에러
     POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4001", "해당하는 게시물이 없습니다."),
-    POST_EDIT_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "POST_4002", "게시물은 작성자만 변경할수 있습니다."),
+    POST_READ_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "POST_4002", "해당 게시물을 읽을 권한이 없습니다."),
+    POST_EDIT_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "POST_4003", "해당 게시물을 수정할 권한이 없습니다."),
+    POST_DELETE_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "POST_4004", "해당 게시물을 삭제할 권한이 없습니다."),
 
     //댓글 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT_4001", "해당하는 댓글이 없습니다."),

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //댓글 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT_4001", "해당하는 댓글이 없습니다."),
+    COMMENT_DELETE_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "COMMENT_4002", "해당 댓글을 삭제할 권한이 없습니다."),
 
     //좋아요 관련 에러
     POST_ALREADY_LIKE(HttpStatus.BAD_REQUEST, "LIKE_4001", "해당하는 게시글은 이미 좋아요인 상태입니다."),

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
@@ -16,6 +16,9 @@ public enum SuccessStatus implements BaseCode {
     POST_OK(HttpStatus.OK, "POST_2000", "Post 관련 요청이 성공적으로 수행되었습니다."),
     POST_CREATED(HttpStatus.CREATED, "POST_2001", "Post 관련 요청이 성공적으로 생성되었습니다."),
 
+    COMMENT_OK(HttpStatus.OK, "COMMENT_2000", "Comment 관련 요청이 성공적으로 수행되었습니다."),
+    COMMENT_CREATED(HttpStatus.CREATED, "COMMENT_2001", "Comment 관련 요청이 성공적으로 생성되었습니다."),
+
     LIKE_OK(HttpStatus.OK, "LIKE_2000", "Like 관련 요청이 성공적으로 수행되었습니다."),
     LIKE_CREATED(HttpStatus.CREATED, "LIKE_2001", "LIKE 관련 요청이 성공적으로 생성되었습니다."),
 

--- a/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
+++ b/src/main/java/capstone/capstone01/global/apipayload/code/status/SuccessStatus.java
@@ -14,6 +14,7 @@ public enum SuccessStatus implements BaseCode {
     USER_CREATED(HttpStatus.CREATED,"USER_2001", "USER 관련 요청이 성공적으로 생성되었습니다."),
 
     POST_OK(HttpStatus.OK, "POST_2000", "Post 관련 요청이 성공적으로 수행되었습니다."),
+    POST_CREATED(HttpStatus.CREATED, "POST_2001", "Post 관련 요청이 성공적으로 생성되었습니다."),
 
     LIKE_OK(HttpStatus.OK, "LIKE_2000", "Like 관련 요청이 성공적으로 수행되었습니다."),
     LIKE_CREATED(HttpStatus.CREATED, "LIKE_2001", "LIKE 관련 요청이 성공적으로 생성되었습니다."),

--- a/src/main/java/capstone/capstone01/global/util/converter/CommentConverter.java
+++ b/src/main/java/capstone/capstone01/global/util/converter/CommentConverter.java
@@ -1,0 +1,33 @@
+package capstone.capstone01.global.util.converter;
+
+import capstone.capstone01.domain.comment.domain.Comment;
+import capstone.capstone01.domain.comment.dto.request.CommentCreateRequestDto;
+import capstone.capstone01.domain.comment.dto.response.CommentResponseDto;
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.user.domain.User;
+
+
+public class CommentConverter {
+
+    public static Comment toComment(CommentCreateRequestDto requestDto, User writer, ImagePost imagePost) {
+        Comment comment = Comment.builder()
+                .content(requestDto.getContent())
+                .writer(writer)
+                .imagePost(imagePost)
+                .isDeleted(false)
+                .build();
+
+        imagePost.addComment(comment); // 양방향 매핑 설정
+        return comment;
+    }
+
+    public static CommentResponseDto toCommentResponseDto(Comment comment) {
+        return CommentResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .writerNickname(comment.getWriter().getNickname())
+                .isDeleted(comment.getIsDeleted())
+                .build();
+    }
+
+}

--- a/src/main/java/capstone/capstone01/global/util/converter/ImagePostConverter.java
+++ b/src/main/java/capstone/capstone01/global/util/converter/ImagePostConverter.java
@@ -1,0 +1,29 @@
+package capstone.capstone01.global.util.converter;
+
+import capstone.capstone01.domain.imagepost.domain.ImagePost;
+import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
+import capstone.capstone01.domain.user.domain.User;
+
+public class ImagePostConverter {
+
+    public static ImagePost toImagePost(PostCreateRequestDto requestDto, User writer) {
+        return ImagePost.builder()
+                .title(requestDto.getTitle())
+                .writer(writer)
+                .isOpen(requestDto.getIsOpen())
+                .isDeleted(false)
+                .build();
+    }
+
+    public static ImagePostResponseDto toImagePostResponseDto(ImagePost imagePost) {
+        return ImagePostResponseDto.builder()
+                .id(imagePost.getId())
+                .title(imagePost.getTitle())
+                .writerNickname(imagePost.getWriter().getNickname())
+                .isOpen(imagePost.getIsOpen())
+                .isDeleted(imagePost.getIsDeleted())
+                .build();
+    }
+
+}

--- a/src/main/java/capstone/capstone01/global/util/converter/ImagePostConverter.java
+++ b/src/main/java/capstone/capstone01/global/util/converter/ImagePostConverter.java
@@ -1,13 +1,13 @@
 package capstone.capstone01.global.util.converter;
 
 import capstone.capstone01.domain.imagepost.domain.ImagePost;
-import capstone.capstone01.domain.imagepost.dto.request.PostCreateRequestDto;
+import capstone.capstone01.domain.imagepost.dto.request.ImagePostCreateRequestDto;
 import capstone.capstone01.domain.imagepost.dto.response.ImagePostResponseDto;
 import capstone.capstone01.domain.user.domain.User;
 
 public class ImagePostConverter {
 
-    public static ImagePost toImagePost(PostCreateRequestDto requestDto, User writer) {
+    public static ImagePost toImagePost(ImagePostCreateRequestDto requestDto, User writer) {
         return ImagePost.builder()
                 .title(requestDto.getTitle())
                 .writer(writer)


### PR DESCRIPTION
### 🚩 관련사항
https://github.com/CapstoneDesignCau/Back-End/issues/17

### 📢 전달사항
게시글과 댓글 관련 생성, 삭제, 조회 로직을 추가합니다.
또한 게시글과 댓글이 양방향 매핑되게 수정하였습니다.

### 📸 스크린샷
-게시글 조회
![게시글 생성](https://github.com/user-attachments/assets/02d7baf0-b70b-404b-9601-302cabc266f5)
-게시글 생성
![생성1](https://github.com/user-attachments/assets/bf86e86d-aa99-471e-9f8f-a86a6a56c973)
![생성1-1](https://github.com/user-attachments/assets/2d79d3ca-15a0-43d7-8dc1-3c427f96eac2)
-게시글 삭제
![게시글 삭제](https://github.com/user-attachments/assets/a878c980-229a-47ef-adfa-b3e47e34886c)

댓글 API Test 추후 추가 예정

### 📃 코드 변경사항 
- [x] 게시글 생성, 삭제, 조회 로직 추가
- [x] 댓글 생성, 삭제, 조회 로직 추가
- [x] 게시글, 댓글 양방향 매핑 

### 📃 추가로 진행할 작업
- [ ] 게시글과 사진 파일 연결
- [ ] 게시글 조회시 해당 게시글 댓글들도 함께 반환하게 수정

### ⚙️ 기타사항
중간고사 끝난 후 추가 작업 예정

